### PR TITLE
Add `get_one` + `delete_one`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metal_sdk"
-version = "0.0.22"
+version = "0.0.23"
 authors = [
   { name="Metal Technologies Inc", email="james@getmetal.io" },
 ]

--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -100,16 +100,21 @@ class Metal(httpx.Client):
         return res.json()
 
     def get_one(self, id: str, app_id=None):
-        app = app_id or self.app_id
-
-        if app is None:
-            raise TypeError("app_id required")
-
         if id is None:
             raise TypeError("id required")
 
         url = "/v1/documents/" + id
 
         res = self.request("get", url)
+        res.raise_for_status()
+        return res.json()
+
+    def delete_one(self, id: str, app_id=None):
+        if id is None:
+            raise TypeError("id required")
+
+        url = "/v1/documents/" + id
+
+        res = self.request("delete", url)
         res.raise_for_status()
         return res.json()

--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -98,3 +98,19 @@ class Metal(httpx.Client):
         res = self.request("post", url, json=data)
         res.raise_for_status()
         return res.json()
+
+
+    def get_one(self, id: str, app_id=None):
+        app = app_id or self.app_id
+
+        if app is None:
+            raise TypeError("app_id required")
+
+        if id is None:
+            raise TypeError("id required")
+
+        url = "/v1/documents/" + id
+
+        res = self.request("get", url)
+        res.raise_for_status()
+        return res.json()

--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -99,7 +99,6 @@ class Metal(httpx.Client):
         res.raise_for_status()
         return res.json()
 
-
     def get_one(self, id: str, app_id=None):
         app = app_id or self.app_id
 

--- a/src/metal_sdk/metal_async.py
+++ b/src/metal_sdk/metal_async.py
@@ -108,3 +108,13 @@ class Metal(httpx.AsyncClient):
         res = await self.request("get", url)
         res.raise_for_status()
         return res.json()
+
+    async def delete_one(self, id: str):
+        if id is None:
+            raise TypeError("id required")
+
+        url = "/v1/documents/" + id
+
+        res = await self.request("delete", url)
+        res.raise_for_status()
+        return res.json()

--- a/src/metal_sdk/metal_async.py
+++ b/src/metal_sdk/metal_async.py
@@ -99,12 +99,7 @@ class Metal(httpx.AsyncClient):
         res.raise_for_status()
         return res.json()
 
-    async def get_one(self, id: str, app_id=None):
-        app = app_id or self.app_id
-
-        if app is None:
-            raise TypeError("app_id required")
-
+    async def get_one(self, id: str):
         if id is None:
             raise TypeError("id required")
 

--- a/src/metal_sdk/metal_async.py
+++ b/src/metal_sdk/metal_async.py
@@ -98,3 +98,18 @@ class Metal(httpx.AsyncClient):
         res = await self.request("post", url, json=data)
         res.raise_for_status()
         return res.json()
+
+    async def get_one(self, id: str, app_id=None):
+        app = app_id or self.app_id
+
+        if app is None:
+            raise TypeError("app_id required")
+
+        if id is None:
+            raise TypeError("id required")
+
+        url = "/v1/documents/" + id
+
+        res = await self.request("get", url)
+        res.raise_for_status()
+        return res.json()

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -116,3 +116,23 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["idA"], payload["idA"])
         self.assertEqual(metal.request.call_args[1]["json"]["idB"], payload["idB"])
         self.assertEqual(metal.request.call_args[1]["json"]["label"], payload["label"])
+
+    def test_metal_get_one_witout_payload(self):
+        app_id = "app-id"
+        metal = Metal(API_KEY, CLIENT_ID, app_id)
+        with self.assertRaises(TypeError) as ctx:
+            metal.get_one()
+        self.assertEqual(str(ctx.exception), "id required")
+
+    def test_metal_get_one_with_payload(self):
+        app_id = "app-id"
+        id = "ozzy"
+        metal = Metal(API_KEY, CLIENT_ID, app_id)
+        return_value = mock.MagicMock(json=lambda: {"ozzy": "black sabbath"})
+        metal.request = mock.MagicMock(return_value=return_value)
+
+        metal.get_one(id)
+        self.assertEqual(metal.request.call_count, 1)
+        self.assertEqual(metal.request.call_args[0][0], "get")
+        self.assertEqual(metal.request.call_args[0][1], "/v1/documents/ozzy")
+        self.assertEqual(metal.request.call_args[1]["json"]["app"], app_id)

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -128,3 +128,15 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_count, 1)
         self.assertEqual(metal.request.call_args[0][0], "get")
         self.assertEqual(metal.request.call_args[0][1], "/v1/documents/ozzy")
+
+    def test_metal_delete_one_with_payload(self):
+        app_id = "app-id"
+        id = "ozzy"
+        metal = Metal(API_KEY, CLIENT_ID, app_id)
+        return_value = mock.MagicMock(json=lambda: {"ozzy": "black sabbath"})
+        metal.request = mock.MagicMock(return_value=return_value)
+
+        metal.delete_one(id)
+        self.assertEqual(metal.request.call_count, 1)
+        self.assertEqual(metal.request.call_args[0][0], "delete")
+        self.assertEqual(metal.request.call_args[0][1], "/v1/documents/ozzy")

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -117,13 +117,6 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["idB"], payload["idB"])
         self.assertEqual(metal.request.call_args[1]["json"]["label"], payload["label"])
 
-    def test_metal_get_one_witout_payload(self):
-        app_id = "app-id"
-        metal = Metal(API_KEY, CLIENT_ID, app_id)
-        with self.assertRaises(TypeError) as ctx:
-            metal.get_one()
-        self.assertEqual(str(ctx.exception), "id required")
-
     def test_metal_get_one_with_payload(self):
         app_id = "app-id"
         id = "ozzy"
@@ -135,4 +128,3 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_count, 1)
         self.assertEqual(metal.request.call_args[0][0], "get")
         self.assertEqual(metal.request.call_args[0][1], "/v1/documents/ozzy")
-        self.assertEqual(metal.request.call_args[1]["json"]["app"], app_id)

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -117,13 +117,6 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["idB"], payload["idB"])
         self.assertEqual(metal.request.call_args[1]["json"]["label"], payload["label"])
 
-    async def test_metal_get_one_witout_payload(self):
-        app_id = "app-id"
-        metal = Metal(API_KEY, CLIENT_ID, app_id)
-        with self.assertRaises(TypeError) as ctx:
-            await metal.get_one()
-        self.assertEqual(str(ctx.exception), "id required")
-
     async def test_metal_get_one_with_payload(self):
         app_id = "app-id"
         id = "dave"
@@ -135,4 +128,3 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_count, 1)
         self.assertEqual(metal.request.call_args[0][0], "get")
         self.assertEqual(metal.request.call_args[0][1], "/v1/documents/dave")
-        self.assertEqual(metal.request.call_args[1]["json"]["app"], app_id)

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -116,3 +116,23 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["idA"], payload["idA"])
         self.assertEqual(metal.request.call_args[1]["json"]["idB"], payload["idB"])
         self.assertEqual(metal.request.call_args[1]["json"]["label"], payload["label"])
+
+    async def test_metal_get_one_witout_payload(self):
+        app_id = "app-id"
+        metal = Metal(API_KEY, CLIENT_ID, app_id)
+        with self.assertRaises(TypeError) as ctx:
+            await metal.get_one()
+        self.assertEqual(str(ctx.exception), "id required")
+
+    async def test_metal_get_one_with_payload(self):
+        app_id = "app-id"
+        id = "dave"
+        metal = Metal(API_KEY, CLIENT_ID, app_id)
+        return_value = mock.MagicMock(json=lambda: {"band": "Megadeth"})
+        metal.request = mock.MagicMock(return_value=return_value)
+
+        await metal.get_one(id")
+        self.assertEqual(metal.request.call_count, 1)
+        self.assertEqual(metal.request.call_args[0][0], "get")
+        self.assertEqual(metal.request.call_args[0][1], "/v1/documents/dave")
+        self.assertEqual(metal.request.call_args[1]["json"]["app"], app_id)

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -128,3 +128,15 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_count, 1)
         self.assertEqual(metal.request.call_args[0][0], "get")
         self.assertEqual(metal.request.call_args[0][1], "/v1/documents/dave")
+
+    async def test_metal_delete_one_with_payload(self):
+        app_id = "app-id"
+        id = "dave"
+        metal = Metal(API_KEY, CLIENT_ID, app_id)
+        return_value = mock.MagicMock(json=lambda: {"band": "Megadeth"})
+        metal.request = mock.MagicMock(return_value=return_value)
+
+        await metal.get_one(id)
+        self.assertEqual(metal.request.call_count, 1)
+        self.assertEqual(metal.request.call_args[0][0], "delete")
+        self.assertEqual(metal.request.call_args[0][1], "/v1/documents/dave")

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -131,7 +131,7 @@ class TestMetal(TestCase):
         return_value = mock.MagicMock(json=lambda: {"band": "Megadeth"})
         metal.request = mock.MagicMock(return_value=return_value)
 
-        await metal.get_one(id")
+        await metal.get_one(id)
         self.assertEqual(metal.request.call_count, 1)
         self.assertEqual(metal.request.call_args[0][0], "get")
         self.assertEqual(metal.request.call_args[0][1], "/v1/documents/dave")


### PR DESCRIPTION
Adds `getOne` method to SDK. This method uses the `/v1/documents/:id` endpoint to fetch a single record from the API.