### PR TITLE
Add `indexMany`

### DIFF
--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -1,6 +1,6 @@
 import httpx
 from typing import List
-from .typings import IndexPayload, SearchPayload, TunePayload
+from .typings import IndexPayload, SearchPayload, TunePayload, BulkIndexItem
 
 
 BASE_API = "https://api.getmetal.io"
@@ -65,6 +65,14 @@ class Metal(httpx.Client):
         self.__validateIndexAndSearch(index, payload)
         data = self.__getData(index, payload)
         url = "/v1/index"
+
+        res = self.request("post", url, json=data)
+        res.raise_for_status()
+        return res.json()
+
+    def index_many(self, payload: List[BulkIndexItem]):
+        url = "/v1/index/bulk"
+        data = {"data": payload}
 
         res = self.request("post", url, json=data)
         res.raise_for_status()

--- a/src/metal_sdk/metal_async.py
+++ b/src/metal_sdk/metal_async.py
@@ -1,6 +1,6 @@
 from typing import List
 import httpx
-from .typings import IndexPayload, SearchPayload, TunePayload
+from .typings import IndexPayload, SearchPayload, TunePayload, BulkIndexItem
 
 
 BASE_API = "https://api.getmetal.io"
@@ -67,6 +67,14 @@ class Metal(httpx.AsyncClient):
         url = "/v1/index"
 
         res = await self.request("post", url, json=data)
+        res.raise_for_status()
+        return res.json()
+
+    async def index_many(self, payload: List[BulkIndexItem]):
+        url = "/v1/index/bulk"
+        data = {"data": payload}
+        res = await self.request("post", url, json=data)
+
         res.raise_for_status()
         return res.json()
 

--- a/src/metal_sdk/typings.py
+++ b/src/metal_sdk/typings.py
@@ -19,6 +19,20 @@ class IndexPayload(TypedDict):
     metadata: NotRequired[dict]
 
 
+class BulkIndexItem(TypedDict):
+    id: NotRequired[str]
+    index: str
+    imageBase64: NotRequired[str]
+    imageUrl: NotRequired[str]
+    text: NotRequired[str]
+    embedding: NotRequired[List[float]]
+    metadata: NotRequired[dict]
+
+
+class BulkIndexPayload(TypedDict):
+    data: List[BulkIndexItem]
+
+
 class SearchFilter(TypedDict):
     field: str
     value: str | int | float

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -55,7 +55,7 @@ class TestMetal(TestCase):
         mock_text = "some text"
         mock_id = "some-id"
         mock_metadata = {"some": "metadata"}
-        payload = [{ "id": mock_id, "text": mock_text, "metadata": mock_metadata, "index": my_index}]
+        payload = [{"id": mock_id, "text": mock_text, "metadata": mock_metadata, "index": my_index}]
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
         metal.request = mock.MagicMock(return_value=mock.Mock(status_code=201))

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -50,6 +50,22 @@ class TestMetal(TestCase):
             metal.request.call_args[1]["json"]["metadata"], payload["metadata"]
         )
 
+    def test_metal_index_many_with_text(self):
+        my_index = "my-index"
+        mock_text = "some text"
+        mock_id = "some-id"
+        mock_metadata = {"some": "metadata"}
+        payload = [{ "id": mock_id, "text": mock_text, "metadata": mock_metadata, "index": my_index}]
+
+        metal = Metal(API_KEY, CLIENT_ID, my_index)
+        metal.request = mock.MagicMock(return_value=mock.Mock(status_code=201))
+        metal.index_many(payload)
+
+        self.assertEqual(metal.request.call_count, 1)
+        self.assertEqual(metal.request.call_args[0][0], "post")
+        self.assertEqual(metal.request.call_args[0][1], "/v1/index/bulk")
+        self.assertEqual(metal.request.call_args[1]["json"]["data"], payload)
+
     def test_metal_search_without_index(self):
         metal = Metal(API_KEY, CLIENT_ID)
         with self.assertRaises(TypeError) as ctx:

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -53,6 +53,27 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["text"], payload["text"])
         self.assertEqual(metal.request.call_args[1]["json"]["metadata"], payload["metadata"])
 
+    async def test_metal_index_with_text(self):
+        my_index = "my-index"
+        mock_text = "some text"
+        mock_id = "some-id"
+        mock_metadata = {"some": "metadata"}
+
+        payload = [{"id": mock_id, "text": mock_text, "metadata": mock_metadata, "index": mock_index}]
+
+        metal = Metal(API_KEY, CLIENT_ID, my_index)
+        metal.request = mock.MagicMock(return_value=mock.Mock(status_code=201))
+        await metal.index_many(payload)
+
+        self.assertEqual(metal.request.call_count, 1)
+        self.assertEqual(
+            metal.request.call_args[0][0], "post"
+        )
+        self.assertEqual(
+            metal.request.call_args[0][1], "/v1/index/bulk"
+        )
+        self.assertEqual(metal.request.call_args[1]["json"]["data"], payload)
+
     async def test_metal_search_without_index(self):
         metal = Metal(API_KEY, CLIENT_ID)
         with self.assertRaises(TypeError) as ctx:

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -53,13 +53,13 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["text"], payload["text"])
         self.assertEqual(metal.request.call_args[1]["json"]["metadata"], payload["metadata"])
 
-    async def test_metal_index_with_text(self):
+    async def test_metal_index_many_with_text(self):
         my_index = "my-index"
         mock_text = "some text"
         mock_id = "some-id"
         mock_metadata = {"some": "metadata"}
 
-        payload = [{"id": mock_id, "text": mock_text, "metadata": mock_metadata, "index": mock_index}]
+        payload = [{"id": mock_id, "text": mock_text, "metadata": mock_metadata, "index": my_index}]
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
         metal.request = mock.MagicMock(return_value=mock.Mock(status_code=201))


### PR DESCRIPTION
Adds new method supported in our API.

With this method users can index up to `100` items in bulk.