### PR TITLE
Add upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metal_sdk"
-version = "1.0.5"
+version = "1.0.6"
 authors = [
   { name="Metal Technologies Inc", email="james@getmetal.io" },
 ]

--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -204,4 +204,4 @@ class Metal(httpx.Client):
         resource = self.__create_resource(index_id, filename, file_type, file_size)
 
         # Upload the file to the returned url
-        self.__upload_file_to_url(resource['url'], file_path, file_type, file_size)
+        self.__upload_file_to_url(resource['data']['url'], file_path, file_type, file_size)

--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -1,3 +1,5 @@
+import os
+import mimetypes
 import httpx
 from typing import List
 from .typings import IndexPayload, SearchPayload, TunePayload, BulkIndexItem
@@ -153,3 +155,55 @@ class Metal(httpx.Client):
         res = self.request("delete", url, json={"ids": ids})
         res.raise_for_status()
         return res.json()
+
+    def __sanitize_filename(self, filename):
+        """
+        Implement your filename sanitation method here.
+        """
+        sanitized_filename = filename.replace(' ', '_')  # Simplified example
+        return sanitized_filename
+
+    def __create_resource(self, index_id, filename, file_type, file_size):
+        url = f'{self.base_url}/indexes/{index_id}/files'
+        payload = {
+            'fileName': self.__sanitize_filename(filename),
+            'fileType': file_type,
+        }
+        headers = {'content-length': str(file_size)}
+
+        res = self.request("post", url, json=payload, headers=headers)
+        res.raise_for_status()  # Raise exception if the request failed
+
+        return res.json()
+
+    def __upload_file_to_url(self, url, file_path, file_type, file_size):
+        with open(file_path, 'rb') as f:
+            headers = {
+                'content-type': file_type,
+                'content-length': str(file_size),
+            }
+            res = self.request("put", url, data=f, headers=headers)
+
+        res.raise_for_status()  # Raise exception if the request failed
+        return res
+
+    def upload_file(self, index_id, file_path):
+        file_size = os.path.getsize(file_path)
+        filename = os.path.basename(file_path)
+        file_type, _ = mimetypes.guess_type(file_path)
+
+        if file_type not in [
+            'application/pdf',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/vnd.ms-excel',
+            'text/csv',
+        ]:
+            raise ValueError("Invalid file type. Supported types are: pdf, docx, csv.")
+
+        # Create resource on the server
+        resource = self.__create_resource(index_id, filename, file_type, file_size)
+
+        # Upload the file to the returned url
+        self.__upload_file_to_url(resource['url'], file_path, file_type, file_size)
+
+        print(f"Upload successful: {file_path}")

--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -205,5 +205,3 @@ class Metal(httpx.Client):
 
         # Upload the file to the returned url
         self.__upload_file_to_url(resource['url'], file_path, file_type, file_size)
-
-        print(f"Upload successful: {file_path}")

--- a/src/metal_sdk/metal_async.py
+++ b/src/metal_sdk/metal_async.py
@@ -1,3 +1,5 @@
+import os
+import mimetypes
 from typing import List
 import httpx
 from .typings import IndexPayload, SearchPayload, TunePayload, BulkIndexItem
@@ -153,3 +155,53 @@ class Metal(httpx.AsyncClient):
         res = await self.request("delete", url, json={"ids": ids})
         res.raise_for_status()
         return res.json()
+
+    def __sanitize_filename(self, filename):
+        """
+        Implement your filename sanitation method here.
+        """
+        sanitized_filename = filename.replace(' ', '_')  # Simplified example
+        return sanitized_filename
+
+    async def __create_resource(self, index_id, filename, file_type, file_size):
+        url = f'{self.base_url}/indexes/{index_id}/files'
+        payload = {
+            'fileName': self.__sanitize_filename(filename),
+            'fileType': file_type,
+        }
+        headers = {'content-length': str(file_size)}
+
+        res = await self.request("post", url, json=payload, headers=headers)
+        res.raise_for_status()  # Raise exception if the request failed
+
+        return res.json()
+
+    async def __upload_file_to_url(self, url, file_path, file_type, file_size):
+        with open(file_path, 'rb') as f:
+            headers = {
+                'content-type': file_type,
+                'content-length': str(file_size),
+            }
+            res = await self.request("put", url, data=f, headers=headers)
+
+        res.raise_for_status()  # Raise exception if the request failed
+        return res
+
+    async def upload_file(self, index_id, file_path):
+        file_size = os.path.getsize(file_path)
+        filename = os.path.basename(file_path)
+        file_type, _ = mimetypes.guess_type(file_path)
+
+        if file_type not in [
+            'application/pdf',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/vnd.ms-excel',
+            'text/csv',
+        ]:
+            raise ValueError("Invalid file type. Supported types are: pdf, docx, csv.")
+
+        # Create resource on the server
+        resource = await self.__create_resource(index_id, filename, file_type, file_size)
+
+        # Upload the file to the returned url
+        await self.__upload_file_to_url(resource['url'], file_path, file_type, file_size)

--- a/src/metal_sdk/metal_async.py
+++ b/src/metal_sdk/metal_async.py
@@ -204,4 +204,4 @@ class Metal(httpx.AsyncClient):
         resource = await self.__create_resource(index_id, filename, file_type, file_size)
 
         # Upload the file to the returned url
-        await self.__upload_file_to_url(resource['url'], file_path, file_type, file_size)
+        await self.__upload_file_to_url(resource['data']['url'], file_path, file_type, file_size)

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -187,7 +187,6 @@ class TestMetal(TestCase):
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
 
-        # Mock the necessary methods
         metal._Metal__create_resource = mock.MagicMock(return_value={'url': 'https://mockuploadurl.com'})
         metal._Metal__upload_file_to_url = mock.MagicMock()
         os.path.getsize = mock.MagicMock(return_value=1000)
@@ -195,18 +194,15 @@ class TestMetal(TestCase):
 
         metal.upload_file(my_index, mock_file_path)
 
-        # Assert that __create_resource and __upload_file_to_url were called
         self.assertEqual(metal._Metal__create_resource.call_count, 1)
         self.assertEqual(metal._Metal__upload_file_to_url.call_count, 1)
 
-        # Check the arguments of __create_resource call
         create_args = metal._Metal__create_resource.call_args[0]
         self.assertEqual(create_args[0], my_index)
         self.assertEqual(create_args[1], "mockfile.csv")
         self.assertEqual(create_args[2], "text/csv")
         self.assertEqual(create_args[3], 1000)
 
-        # Check the arguments of __upload_file_to_url call
         upload_args = metal._Metal__upload_file_to_url.call_args[0]
         self.assertEqual(upload_args[0], 'https://mockuploadurl.com')
         self.assertEqual(upload_args[1], mock_file_path)

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -187,7 +187,7 @@ class TestMetal(TestCase):
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
 
-        metal._Metal__create_resource = mock.MagicMock(return_value={'url': 'https://mockuploadurl.com'})
+        metal._Metal__create_resource = mock.MagicMock(return_value={'data': {'url': 'https://mockuploadurl.com'} })
         metal._Metal__upload_file_to_url = mock.MagicMock()
         os.path.getsize = mock.MagicMock(return_value=1000)
         os.path.basename = mock.MagicMock(return_value="mockfile.csv")

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -187,7 +187,7 @@ class TestMetal(TestCase):
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
 
-        metal._Metal__create_resource = mock.MagicMock(return_value={'data': {'url': 'https://mockuploadurl.com'} })
+        metal._Metal__create_resource = mock.MagicMock(return_value={'data':{'url': 'https://mockuploadurl.com'}})
         metal._Metal__upload_file_to_url = mock.MagicMock()
         os.path.getsize = mock.MagicMock(return_value=1000)
         os.path.basename = mock.MagicMock(return_value="mockfile.csv")

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -187,7 +187,7 @@ class TestMetal(TestCase):
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
 
-        metal._Metal__create_resource = mock.MagicMock(return_value={'data':{'url': 'https://mockuploadurl.com'}})
+        metal._Metal__create_resource = mock.MagicMock(return_value={'data': {'url': 'https://mockuploadurl.com'}})
         metal._Metal__upload_file_to_url = mock.MagicMock()
         os.path.getsize = mock.MagicMock(return_value=1000)
         os.path.basename = mock.MagicMock(return_value="mockfile.csv")

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -186,7 +186,7 @@ class TestMetal(TestCase):
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
 
-        metal._Metal__create_resource = mock.MagicMock(return_value={'data':{'url': 'https://mockuploadurl.com'}})
+        metal._Metal__create_resource = mock.MagicMock(return_value={'data': {'url': 'https://mockuploadurl.com'}})
         metal._Metal__upload_file_to_url = mock.MagicMock()
         os.path.getsize = mock.MagicMock(return_value=1000)
         os.path.basename = mock.MagicMock(return_value="mockfile.csv")

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase, mock
 from src.metal_sdk.metal_async import Metal
 
@@ -178,3 +179,31 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[0][0], "delete")
         self.assertEqual(metal.request.call_args[0][1], "/v1/documents/bulk")
         self.assertEqual(metal.request.call_args[1]["json"]["ids"], [id])
+
+    async def test_upload_file(self):
+        my_index = "my-index"
+        mock_file_path = "/path/to/mockfile.csv"
+
+        metal = Metal(API_KEY, CLIENT_ID, my_index)
+
+        metal._Metal__create_resource = mock.MagicMock(return_value={'url': 'https://mockuploadurl.com'})
+        metal._Metal__upload_file_to_url = mock.MagicMock()
+        os.path.getsize = mock.MagicMock(return_value=1000)
+        os.path.basename = mock.MagicMock(return_value="mockfile.csv")
+
+        await metal.upload_file(my_index, mock_file_path)
+
+        self.assertEqual(metal._Metal__create_resource.call_count, 1)
+        self.assertEqual(metal._Metal__upload_file_to_url.call_count, 1)
+
+        create_args = metal._Metal__create_resource.call_args[0]
+        self.assertEqual(create_args[0], my_index)
+        self.assertEqual(create_args[1], "mockfile.csv")
+        self.assertEqual(create_args[2], "text/csv")
+        self.assertEqual(create_args[3], 1000)
+
+        upload_args = metal._Metal__upload_file_to_url.call_args[0]
+        self.assertEqual(upload_args[0], 'https://mockuploadurl.com')
+        self.assertEqual(upload_args[1], mock_file_path)
+        self.assertEqual(upload_args[2], "text/csv")
+        self.assertEqual(upload_args[3], 1000)

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -186,7 +186,7 @@ class TestMetal(TestCase):
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
 
-        metal._Metal__create_resource = mock.MagicMock(return_value={'url': 'https://mockuploadurl.com'})
+        metal._Metal__create_resource = mock.MagicMock(return_value={'data': {'url': 'https://mockuploadurl.com'} })
         metal._Metal__upload_file_to_url = mock.MagicMock()
         os.path.getsize = mock.MagicMock(return_value=1000)
         os.path.basename = mock.MagicMock(return_value="mockfile.csv")

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -186,7 +186,7 @@ class TestMetal(TestCase):
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
 
-        metal._Metal__create_resource = mock.MagicMock(return_value={'data': {'url': 'https://mockuploadurl.com'} })
+        metal._Metal__create_resource = mock.MagicMock(return_value={'data':{'url': 'https://mockuploadurl.com'}})
         metal._Metal__upload_file_to_url = mock.MagicMock()
         os.path.getsize = mock.MagicMock(return_value=1000)
         os.path.basename = mock.MagicMock(return_value="mockfile.csv")


### PR DESCRIPTION
## Adds `upload_file`

This methods abstracts away file upload for consumers.
- It generates the `file` resource and the url to upload.
- It uses the returned url to upload the data.
