### PR TITLE
Filters v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metal_sdk"
-version = "1.0.10"
+version = "2.0.0"
 authors = [
   { name="Metal Technologies Inc", email="james@getmetal.io" },
 ]

--- a/src/metal_sdk/typings.py
+++ b/src/metal_sdk/typings.py
@@ -33,15 +33,13 @@ class BulkIndexPayload(TypedDict):
     data: List[BulkIndexItem]
 
 
-class SearchFilter(TypedDict):
-    and: NotRequired[List[SearchClause]]
-    or: NotRequired[List[SearchClause]]
-
-
 class SearchClause(TypedDict):
     field: str
     value: str | int | float
     operator: str
+
+
+SearchFilter = TypedDict('SearchFilter', {'and': List[SearchClause], 'or': List[SearchClause]})
 
 
 class SearchPayload(TypedDict):

--- a/src/metal_sdk/typings.py
+++ b/src/metal_sdk/typings.py
@@ -34,8 +34,14 @@ class BulkIndexPayload(TypedDict):
 
 
 class SearchFilter(TypedDict):
+    and: NotRequired[List[SearchClause]]
+    or: NotRequired[List[SearchClause]]
+
+
+class SearchClause(TypedDict):
     field: str
     value: str | int | float
+    operator: str
 
 
 class SearchPayload(TypedDict):
@@ -43,7 +49,7 @@ class SearchPayload(TypedDict):
     imageUrl: NotRequired[str]
     text: NotRequired[str]
     embedding: NotRequired[List[float]]
-    filters: NotRequired[List[SearchFilter]]
+    filters: NotRequired[SearchFilter]
 
 
 class TunePayload(TypedDict):

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -134,7 +134,7 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["index"], my_index)
         self.assertEqual(metal.request.call_args[1]["json"]["text"], payload["text"])
         self.assertEqual(
-            metal.request.call_args[1]["json"]["filters"]["and"], payload["filters"]
+            metal.request.call_args[1]["json"]["filters"], payload["filters"]
         )
 
     def test_metal_tune_without_index(self):

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -92,7 +92,7 @@ class TestMetal(TestCase):
         metal = Metal(API_KEY, CLIENT_ID, my_index)
 
         metal.request = mock.MagicMock(return_value=mock.Mock(status_code=200))
-        metal.search({"filters": [{"field": "foo", "value": "bar"}]}, limit=666)
+        metal.search({"filters": {"and": [{"field": "foo", "value": "bar", "operator": "eq"}]}}, limit=666)
 
         self.assertEqual(metal.request.call_count, 1)
         self.assertEqual(
@@ -106,14 +106,14 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["index"], my_index)
         self.assertEqual(metal.request.call_args[1]["json"].get("text"), None)
         self.assertEqual(
-            metal.request.call_args[1]["json"]["filters"], [{"field": "foo", "value": "bar"}]
+            metal.request.call_args[1]["json"]["filters"]["and"], [{"field": "foo", "value": "bar", "operator": "eq"}]
         )
 
     def test_metal_search_with_text(self):
         my_index = "my-index"
         payload = {
             "text": "some text",
-            "filters": [{"field": "number_of_the_beast", "value": 666}],
+            "filters": {"and": [{"field": "number_of_the_beast", "value": 666, "operator": "lt"}]},
         }
 
         metal = Metal(API_KEY, CLIENT_ID, my_index)
@@ -134,7 +134,7 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[1]["json"]["index"], my_index)
         self.assertEqual(metal.request.call_args[1]["json"]["text"], payload["text"])
         self.assertEqual(
-            metal.request.call_args[1]["json"]["filters"], payload["filters"]
+            metal.request.call_args[1]["json"]["filters"]["and"], payload["filters"]
         )
 
     def test_metal_tune_without_index(self):


### PR DESCRIPTION
Adds `and` and `or` clauses.

With `eq` `gt` `gte` `lte` an `lt` operators.

Breaks how we handle filters, but bumps major version change.