### PR TITLE
inject index id with bulk indexing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metal_sdk"
-version = "2.0.5"
+version = "2.0.6"
 authors = [
   { name="Metal Technologies Inc", email="james@getmetal.io" },
 ]

--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -91,6 +91,11 @@ class Metal(httpx.Client):
 
     def index_many(self, payload: List[BulkIndexItem]):
         url = "/v1/index/bulk"
+
+        for item in payload:
+            if item.get("index") is None:
+                item["index"] = self.index_id
+
         data = {"data": payload}
         res = self.fetch("post", url, data)
         return res

--- a/src/metal_sdk/metal_async.py
+++ b/src/metal_sdk/metal_async.py
@@ -91,6 +91,11 @@ class Metal(httpx.AsyncClient):
 
     async def index_many(self, payload: List[BulkIndexItem]):
         url = "/v1/index/bulk"
+
+        for item in payload:
+            if item.get("index") is None:
+                item["index"] = self.index_id
+
         data = {"data": payload}
         res = await self.fetch("post", url, data)
         return res

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -80,6 +80,23 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[0][0], "post")
         self.assertEqual(metal.request.call_args[0][1], "/v1/index/bulk")
         self.assertEqual(metal.request.call_args[1]["json"]["data"], payload)
+    
+    def test_metal_index_many_with_indexid(self):
+        my_index = "my-index"
+        mock_text = "some text"
+        mock_id = "some-id"
+        mock_metadata = {"some": "metadata"}
+        payload = [{"id": mock_id, "text": mock_text, "metadata": mock_metadata}]
+        payload_with_index = [{"id": mock_id, "text": mock_text, "metadata": mock_metadata, "index": my_index}]
+
+        metal = Metal(API_KEY, CLIENT_ID, my_index)
+        metal.request = mock.MagicMock(return_value=mock.Mock(status_code=201))
+        metal.index_many(payload)
+
+        self.assertEqual(metal.request.call_count, 1)
+        self.assertEqual(metal.request.call_args[0][0], "post")
+        self.assertEqual(metal.request.call_args[0][1], "/v1/index/bulk")
+        self.assertEqual(metal.request.call_args[1]["json"]["data"], payload_with_index)
 
     def test_metal_search_without_index(self):
         metal = Metal(API_KEY, CLIENT_ID)

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -80,7 +80,7 @@ class TestMetal(TestCase):
         self.assertEqual(metal.request.call_args[0][0], "post")
         self.assertEqual(metal.request.call_args[0][1], "/v1/index/bulk")
         self.assertEqual(metal.request.call_args[1]["json"]["data"], payload)
-    
+
     def test_metal_index_many_with_indexid(self):
         my_index = "my-index"
         mock_text = "some text"

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -96,7 +96,7 @@ class TestMetal(IsolatedAsyncioTestCase):
             metal.request.call_args[0][1], "/v1/index/bulk"
         )
         self.assertEqual(metal.request.call_args[1]["json"]["data"], payload)
-    
+
     async def test_metal_index_many_with_indexid(self):
         my_index = "my-index"
         mock_text = "some text"

--- a/tests/test_metal_async.py
+++ b/tests/test_metal_async.py
@@ -96,6 +96,32 @@ class TestMetal(IsolatedAsyncioTestCase):
             metal.request.call_args[0][1], "/v1/index/bulk"
         )
         self.assertEqual(metal.request.call_args[1]["json"]["data"], payload)
+    
+    async def test_metal_index_many_with_indexid(self):
+        my_index = "my-index"
+        mock_text = "some text"
+        mock_id = "some-id"
+        mock_metadata = {"some": "metadata"}
+
+        payload = [{"id": mock_id, "text": mock_text, "metadata": mock_metadata}]
+        payload_with_index = [{"id": mock_id, "text": mock_text, "metadata": mock_metadata, "index": my_index}]
+
+        metal = Metal(API_KEY, CLIENT_ID, my_index)
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": "foo"}
+
+        metal.request = mock.AsyncMock(return_value=mock_response)
+        await metal.index_many(payload)
+
+        self.assertEqual(metal.request.call_count, 1)
+        self.assertEqual(
+            metal.request.call_args[0][0], "post"
+        )
+        self.assertEqual(
+            metal.request.call_args[0][1], "/v1/index/bulk"
+        )
+        self.assertEqual(metal.request.call_args[1]["json"]["data"], payload_with_index)
 
     async def test_metal_search_without_index(self):
         metal = Metal(API_KEY, CLIENT_ID)


### PR DESCRIPTION
This was a point of confusion for multiple users. We take the index id with the Metal constructor but it doesn't add the `index` to items within the `index_many` method