### PR TITLE
Return consistent list from `get_many`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metal_sdk"
-version = "2.5.0"
+version = "2.5.1"
 authors = [
   { name="Metal Technologies Inc", email="james@getmetal.io" },
 ]

--- a/src/metal_sdk/metal.py
+++ b/src/metal_sdk/metal.py
@@ -192,7 +192,11 @@ class Metal(httpx.Client):
         url = "/v1/indexes/" + index + "/documents/" + id_str
 
         res = self.fetch("get", url, None)
-        return res
+
+        if isinstance(res, list):
+            return res
+        else:
+            return [res]
 
     def delete_one(self, id: str, index_id=None):
         index = index_id or self.index_id

--- a/src/metal_sdk/metal_async.py
+++ b/src/metal_sdk/metal_async.py
@@ -192,7 +192,11 @@ class Metal(httpx.AsyncClient):
         url = "/v1/indexes/" + index + "/documents/" + id_str
 
         res = await self.fetch("get", url, None)
-        return res
+
+        if isinstance(res, list):
+            return res
+        else:
+            return [res]
 
     async def delete_one(self, id: str, index_id=None):
         index = index_id or self.index_id


### PR DESCRIPTION
Fixes issue when a single `id` is passed to get_many it doesn't return a list.